### PR TITLE
Ensure dependencies are bundled in chart

### DIFF
--- a/.github/actions/helm-chart-oci-publisher/action.yml
+++ b/.github/actions/helm-chart-oci-publisher/action.yml
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        helm package '${{ steps.chart-path.outputs.result }}' --version '${{ inputs.chart_version }}'
+        helm package --dependency-update '${{ steps.chart-path.outputs.result }}' --version '${{ inputs.chart_version }}'
     - name: Push the packaged chart to the registry
       id: result
       shell: bash


### PR DESCRIPTION
Resolve this error in lfx-v2-helm:

```
Error: found in Chart.yaml, but missing in charts/ directory: traefik, openfga, heimdall, nats, opensearch, mailpit, authelia, nack
Error: Process completed with exit code 1.
```

Since we don't "vendor" in our subcharts into Git, we need the `--dependency-update` flag to do this dynamically as part of the build, otherwise the Chart build fails.