### PR TITLE
Always clobber chart version with passed value

### DIFF
--- a/.github/actions/helm-chart-oci-publisher/action.yml
+++ b/.github/actions/helm-chart-oci-publisher/action.yml
@@ -76,6 +76,11 @@ runs:
         set -euo pipefail
         CHART_PATH="${{ !inputs.path && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}"
         echo "result=$CHART_PATH" >> "$GITHUB_OUTPUT"
+    - name: Set version in Chart.yaml
+      shell: bash
+      run: |
+        set -euo pipefail
+        yq eval '.version = "${{ inputs.chart_version }}"' -i '${{ steps.chart-path.outputs.result }}/Chart.yaml'
     - name: Set appVersion in Chart.yaml
       if: inputs.app_version != ''
       shell: bash


### PR DESCRIPTION
Currently, this shared action requires a chart version, which the callers all currently extract FROM Chart.yaml, and then this passed version is used in the shared action for file names. (Which is an odd choice, since THIS action could have just extracted it, but oh well.)

Anyhow, by always doing an inline edit of Chart.yaml to set/replace the Chart's `version` attribute with the passed version, we will also now allow the callers to choose a different mechanism (namely, the release tag), to set the chart version.

*Note, unlike the appVersion step that follows this one, the chart-version set doesn't require an "if", because the `chart_version` input is marked as required.*