### PR TITLE
Drop unused pull-requests:write permission from license-header-check

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -25,7 +25,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   license-header-check:


### PR DESCRIPTION
## Summary

- Removes the `pull-requests: write` permission from the reusable `license-header-check.yml` workflow.
- The workflow only reads repo contents and reports pass/fail via the job exit code — it does not call the GitHub API to post PR comments, create check runs, add labels, or otherwise mutate PR state, so the scope was unused.
- `contents: read` alone is sufficient for `actions/checkout@v4` and the inline `git ls-files` / `grep` license scan, following least-privilege.

## Verification

- Confirmed no `gh`, `actions/github-script`, `peter-evans/*`, or `curl https://api.github.com` calls anywhere in the workflow.
- Existing callers (e.g. [`lfx-self-serve`](https://github.com/linuxfoundation/lfx-self-serve/blob/main/.github/workflows/license-header-check.yml)) already invoke this reusable workflow with only `contents: read` at the caller level — no behavior change for consumers.

## Test plan

- [ ] CI green on this PR.
- [ ] Spot-check at least one downstream caller's next CI run to confirm license-header-check still reports status correctly.


Made with [Cursor](https://cursor.com)