### PR TITLE
Publicise our Tofu wrapper workflows

### DIFF
--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -77,15 +77,6 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      cloudflare_setup_warp_client:
-        description: "Setup Cloudflare WARP Client"
-        required: false
-        default: false
-        type: boolean
-      cloudflare_organization:
-        description: "Cloudflare organization"
-        required: false
-        type: string
       rds_proxy:
         description: "Start/stop the RDS Proxy"
         required: false
@@ -140,10 +131,6 @@ jobs:
           EOF
           )"
 
-          # Mask individual secrets directly
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -192,16 +179,6 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_path || '.' }}
-
-        # Cloudflare WARP client setup if needed
-      - name: "Cloudflare Warp Setup"
-        if: ${{ inputs.cloudflare_setup_warp_client }}
-        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
-        with:
-          organization: ${{ inputs.cloudflare_organization }}
-          # Get secrets from environment variables exported by secretsmanager
-          auth_client_id: ${{ env.cloudflare_auth_client_id }}
-          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
 
       - name: OpenTofu Apply
         uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Environment Variables
         id: set-env
@@ -140,7 +140,7 @@ jobs:
 
       # This is used to fetch build time secrets from AWS Secrets Manager
       - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
         if: ${{ inputs.secrets_manager_keys != '' }}
         with:
           secret-ids: ${{ inputs.secrets_manager_keys }}

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -1,4 +1,9 @@
+---
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 name: OpenTofu Apply
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -77,8 +77,8 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      rds_proxy:
-        description: "Start/stop the RDS Proxy"
+      pre_run_script:
+        description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
         default: false
         type: boolean
@@ -192,45 +192,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: |
-            if [ "${{ inputs.rds_proxy }}" = true ]; then
-              set -euo pipefail
-
-              # Install netcat
-              apt-get update && apt-get install -y netcat-openbsd
-
-              # Install awscli v2
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip awscliv2.zip
-              ./aws/install
-
-              # Install kubectl
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-              chmod +x kubectl
-              mv kubectl /usr/local/bin/
-
-              # Start RDS Proxy
-              echo "Starting RDS proxy"
-              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
-
-              sleep 5
-
-              # Check if RDS proxy started
-              echo "Checking if RDS proxy started..."
-              for i in {1..6}; do
-                if nc -z localhost 5432; then
-                  echo "✅ RDS proxy is ready!"
-                  break
-                elif [ $i -eq 6 ]; then
-                  echo "❌ RDS proxy failed to start after 30 seconds"
-                  docker logs rds-proxy
-                  exit 1
-                else
-                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
-                  sleep 5
-                fi
-              done
-            fi
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -1,0 +1,259 @@
+name: OpenTofu Apply
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Name of the environment to use'
+        required: true
+        type: string
+      opentofu_workspace:
+        description: 'Name of the OpenTofu workspace to use, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_variables:
+        description: 'Variables to pass to OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_backend_config:
+        description: 'Backend configuration for OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_plan_label:
+        description: 'Label for the OpenTofu plan output, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_var_file:
+        description: 'List of var file paths, one per line'
+        required: false
+        default: ''
+        type: string
+      opentofu_auto_approve:
+        description: 'Automatically approve and apply plan'
+        required: false
+        default: "false"
+        type: string
+      opentofu_path:
+        description: 'Path to the OpenTofu directory'
+        required: false
+        default: '.'
+        type: string
+      oidc_role_arn:
+        description: 'ARN of the IAM role to assume with OIDC'
+        required: true
+        default: ''
+        type: string
+      oidc_audience:
+        description: 'OIDC audience to authenticate against'
+        required: false
+        default: 'sts.amazonaws.com'
+        type: string
+      oidc_region:
+        description: 'Default region for AWS client'
+        required: false
+        default: us-east-2
+        type: string
+      trigger_apply:
+        description: 'Whether to trigger the OpenTofu apply job'
+        required: false
+        default: true
+        type: boolean
+      env:
+        description: 'Extra environment variables'
+        required: false
+        type: string
+      secrets_manager_keys:
+        description: 'List of keys to fetch from AWS Secrets Manager'
+        required: false
+        type: string
+      artifact_name:
+        description: "The artifact name to download"
+        required: false
+        type: string
+      artifact_path:
+        description: "The artifact path to download"
+        required: false
+        type: string
+      cloudflare_setup_warp_client:
+        description: "Setup Cloudflare WARP Client"
+        required: false
+        default: false
+        type: boolean
+      cloudflare_organization:
+        description: "Cloudflare organization"
+        required: false
+        type: string
+      rds_proxy:
+        description: "Start/stop the RDS Proxy"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      env_secret:
+        description: 'Extra secret environment variables'
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  opentofu_apply:
+    runs-on: ubuntu-latest
+    name: "OpenTofu Apply - ${{ inputs.environment }}"
+    environment: ${{ inputs.environment }}
+    if: ${{ inputs.trigger_apply }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Environment Variables
+        id: set-env
+        shell: bash
+        run: |
+          # Add env_secret to environment using heredoc to preserve all characters
+          cat <<'EOF' >> $GITHUB_ENV
+          ${{ secrets.env_secret }}
+          EOF
+
+          # Function to safely process each line of a secret
+          process_secret() {
+            # Use printf to avoid echo interpretation issues
+            printf "%s\n" "$1" | while IFS= read -r line; do
+              if [[ "$line" == *"="* ]]; then
+                value="${line#*=}"
+                if [[ -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                fi
+              fi
+            done
+          }
+
+          # Process env_secret for masking
+          process_secret "$(cat <<'EOF'
+          ${{ secrets.env_secret }}
+          EOF
+          )"
+
+          # Mask individual secrets directly
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: ${{ inputs.oidc_audience }}
+          role-to-assume: ${{ inputs.oidc_role_arn }}
+          aws-region: ${{ inputs.oidc_region }}
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        if: ${{ inputs.secrets_manager_keys != '' }}
+        with:
+          secret-ids: ${{ inputs.secrets_manager_keys }}
+          name-transformation: none
+
+      # For each env var that matches TERRAFORM_HTTP_CREDENTIALS_* add it to the TERRAFORM_HTTP_CREDENTIALS with a newline
+      - name: Set Terraform HTTP Credentials
+        run: |
+          # Initialize TERRAFORM_HTTP_CREDENTIALS if not set
+          : "${TERRAFORM_HTTP_CREDENTIALS:=""}"
+
+          # Find credential variables
+          credential_vars=$(compgen -A variable | grep '^TERRAFORM_HTTP_CREDENTIALS_' || true)
+
+          if [ -n "$credential_vars" ]; then
+            for var in $credential_vars; do
+              # Validate credential format
+              if [ -z "${!var}" ]; then
+                echo "::error::Empty credential found in $var"
+                exit 1
+              fi
+              TERRAFORM_HTTP_CREDENTIALS="${TERRAFORM_HTTP_CREDENTIALS}${!var}"$'\n'
+            done
+            # Export multi-line environment variable for subsequent steps
+            echo "TERRAFORM_HTTP_CREDENTIALS<<EOF" >> $GITHUB_ENV
+            echo "$TERRAFORM_HTTP_CREDENTIALS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
+          fi
+
+      # Conditionally download the artifact if the artifact_name input is provided
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || '.' }}
+
+        # Cloudflare WARP client setup if needed
+      - name: "Cloudflare Warp Setup"
+        if: ${{ inputs.cloudflare_setup_warp_client }}
+        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
+        with:
+          organization: ${{ inputs.cloudflare_organization }}
+          # Get secrets from environment variables exported by secretsmanager
+          auth_client_id: ${{ env.cloudflare_auth_client_id }}
+          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
+
+      - name: OpenTofu Apply
+        uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3
+        with:
+          label: ${{ inputs.opentofu_plan_label || inputs.environment }}
+          workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
+          backend_config: ${{ inputs.opentofu_backend_config }}
+          var_file: ${{ inputs.opentofu_var_file }}
+          auto_approve: ${{ inputs.opentofu_auto_approve }}
+          path: ${{ inputs.opentofu_path }}
+          variables: |
+            ${{ inputs.opentofu_variables }}
+        env:
+          TERRAFORM_PRE_RUN: |
+            if [ "${{ inputs.rds_proxy }}" = true ]; then
+              set -euo pipefail
+
+              # Install netcat
+              apt-get update && apt-get install -y netcat-openbsd
+
+              # Install awscli v2
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              ./aws/install
+
+              # Install kubectl
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              # Start RDS Proxy
+              echo "Starting RDS proxy"
+              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
+
+              sleep 5
+
+              # Check if RDS proxy started
+              echo "Checking if RDS proxy started..."
+              for i in {1..6}; do
+                if nc -z localhost 5432; then
+                  echo "✅ RDS proxy is ready!"
+                  break
+                elif [ $i -eq 6 ]; then
+                  echo "❌ RDS proxy failed to start after 30 seconds"
+                  docker logs rds-proxy
+                  exit 1
+                else
+                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
+                  sleep 5
+                fi
+              done
+            fi
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -178,7 +178,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_script }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           # Add env_secret to environment using heredoc to preserve all characters
           cat <<'EOF' >> $GITHUB_ENV
+          ${{ inputs.env }}
           ${{ secrets.env_secret }}
           EOF
 

--- a/.github/workflows/lfx-opentofu-apply.yml
+++ b/.github/workflows/lfx-opentofu-apply.yml
@@ -14,32 +14,22 @@ on:
       opentofu_workspace:
         description: 'Name of the OpenTofu workspace to use, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_variables:
         description: 'Variables to pass to OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_backend_config:
         description: 'Backend configuration for OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_plan_label:
         description: 'Label for the OpenTofu plan output, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_var_file:
         description: 'List of var file paths, one per line'
         required: false
-        default: ''
-        type: string
-      opentofu_auto_approve:
-        description: 'Automatically approve and apply plan'
-        required: false
-        default: "false"
         type: string
       opentofu_path:
         description: 'Path to the OpenTofu directory'
@@ -49,7 +39,6 @@ on:
       oidc_role_arn:
         description: 'ARN of the IAM role to assume with OIDC'
         required: true
-        default: ''
         type: string
       oidc_audience:
         description: 'OIDC audience to authenticate against'
@@ -61,11 +50,6 @@ on:
         required: false
         default: us-east-2
         type: string
-      trigger_apply:
-        description: 'Whether to trigger the OpenTofu apply job'
-        required: false
-        default: true
-        type: boolean
       env:
         description: 'Extra environment variables'
         required: false
@@ -85,8 +69,7 @@ on:
       pre_run_script:
         description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
-        default: false
-        type: boolean
+        type: string
     secrets:
       env_secret:
         description: 'Extra secret environment variables'
@@ -102,7 +85,6 @@ jobs:
     runs-on: ubuntu-latest
     name: "OpenTofu Apply - ${{ inputs.environment }}"
     environment: ${{ inputs.environment }}
-    if: ${{ inputs.trigger_apply }}
 
     steps:
       - name: Checkout
@@ -192,7 +174,6 @@ jobs:
           workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
           backend_config: ${{ inputs.opentofu_backend_config }}
           var_file: ${{ inputs.opentofu_var_file }}
-          auto_approve: ${{ inputs.opentofu_auto_approve }}
           path: ${{ inputs.opentofu_path }}
           variables: |
             ${{ inputs.opentofu_variables }}

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -1,7 +1,9 @@
+---
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 
 name: OpenTofu Check
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -217,6 +217,7 @@ jobs:
         run: |
           echo "OpenTofu check failed - drift detected in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \
+            --fail-with-body \
             -X POST \
             -H 'Authorization: Bearer ${{ env.INCIDENT_ALERT_TOKEN }}' \
             -H 'Content-Type: application/json' \
@@ -234,6 +235,7 @@ jobs:
         run: |
           echo "OpenTofu check failed - error detecting drift in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \
+            --fail-with-body \
             -X POST \
             -H 'Authorization: Bearer ${{ env.INCIDENT_ALERT_TOKEN }}' \
             -H 'Content-Type: application/json' \

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -176,7 +176,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_script }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -14,27 +14,22 @@ on:
       opentofu_workspace:
         description: "Name of the OpenTofu workspace to use, defaults to environment"
         required: false
-        default: ""
         type: string
       opentofu_variables:
         description: "Variables to pass to OpenTofu"
         required: false
-        default: ""
         type: string
       opentofu_backend_config:
         description: "Backend configuration for OpenTofu"
         required: false
-        default: ""
         type: string
       opentofu_plan_label:
         description: "Label for the OpenTofu plan output, defaults to environment"
         required: false
-        default: ""
         type: string
       opentofu_var_file:
         description: "List of var file paths, one per line"
         required: false
-        default: ""
         type: string
       opentofu_path:
         description: "Path to the OpenTofu directory"
@@ -44,7 +39,6 @@ on:
       oidc_role_arn:
         description: "ARN of the IAM role to assume with OIDC"
         required: true
-        default: ""
         type: string
       oidc_audience:
         description: "OIDC audience to authenticate against"
@@ -56,11 +50,6 @@ on:
         required: false
         default: us-east-2
         type: string
-      trigger_check:
-        description: "Whether to trigger the OpenTofu check job"
-        required: false
-        default: true
-        type: boolean
       env:
         description: "Extra environment variables"
         required: false
@@ -80,8 +69,7 @@ on:
       pre_run_script:
         description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
-        default: false
-        type: boolean
+        type: string
       disable_incidentio_alert:
         description: "Disable Incident.io alert creation on drift detection"
         required: false
@@ -111,7 +99,6 @@ jobs:
   opentofu_check:
     runs-on: ubuntu-latest
     name: "OpenTofu Check - ${{ inputs.environment }}"
-    if: ${{ inputs.trigger_check }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -70,10 +70,10 @@ on:
         description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
         type: string
-      disable_incidentio_alert:
-        description: "Disable Incident.io alert creation on drift detection"
+      enable_incidentio_alert:
+        description: "Enable Incident.io alert creation on drift detection"
         required: false
-        default: false
+        default: true
         type: boolean
       incidentio_alert_token:
         description: "Incident.io alert token Secrets Manager source (ENVVAR, /secret/path)"
@@ -130,7 +130,7 @@ jobs:
       # Skip reading incident secrets if none given or alert is disabled
       - name: Read Incident.io secrets from AWS Secrets Manager into environment variables
         uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        if: ${{ !inputs.disable_incidentio_alert && (inputs.incidentio_alert_token != '' && inputs.incidentio_alert_source != '') }}
+        if: ${{ inputs.enable_incidentio_alert && (inputs.incidentio_alert_token != '' && inputs.incidentio_alert_source != '') }}
         with:
           secret-ids: |
             ${{ inputs.incidentio_alert_token }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Create Incident.io Alert on Drift
         id: create-alert
-        if: ${{ !inputs.disable_incidentio_alert && steps.opentofu-check.outputs.failure-reason == 'changes-to-apply' }}
+        if: ${{ inputs.enable_incidentio_alert && steps.opentofu-check.outputs.failure-reason == 'changes-to-apply' }}
         run: |
           echo "OpenTofu check failed - drift detected in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \
@@ -200,7 +200,7 @@ jobs:
 
       - name: Create Incident.io Alert on Error
         id: create-error-alert
-        if: ${{ !inputs.disable_incidentio_alert && steps.opentofu-check.outcome == 'failure' && steps.opentofu-check.outputs.failure-reason != 'changes-to-apply' }}
+        if: ${{ inputs.enable_incidentio_alert && steps.opentofu-check.outcome == 'failure' && steps.opentofu-check.outputs.failure-reason != 'changes-to-apply' }}
         run: |
           echo "OpenTofu check failed - error detecting drift in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \
@@ -219,7 +219,7 @@ jobs:
         if: always()
         run: |
           # Separate print statements if alert creation is disabled
-          if [[ "${{ inputs.disable_incidentio_alert }}" == "true" ]]; then
+          if [[ "${{ inputs.enable_incidentio_alert }}" == "false" ]]; then
             if [[ "${{ steps.opentofu-check.outputs.failure-reason }}" == "changes-to-apply" ]]; then
               echo "⚠️ Drift detected but Incident.io alert creation is disabled"
               exit 0

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -106,10 +106,32 @@ jobs:
 
       - name: Set Environment Variables
         id: set-env
+        shell: bash
         run: |
-          echo -e '${{ inputs.env }}' >> $GITHUB_ENV
-          for val in $(echo -e '${{ secrets.env_secret }}' | cut -d'=' -f2-); do echo ::add-mask::$val ; done
-          echo -e '${{ secrets.env_secret }}' >> $GITHUB_ENV
+          # Add env_secret to environment using heredoc to preserve all characters
+          cat <<'EOF' >> $GITHUB_ENV
+          ${{ inputs.env }}
+          ${{ secrets.env_secret }}
+          EOF
+
+          # Function to safely process each line of a secret
+          process_secret() {
+            # Use printf to avoid echo interpretation issues
+            printf "%s\n" "$1" | while IFS= read -r line; do
+              if [[ "$line" == *"="* ]]; then
+                value="${line#*=}"
+                if [[ -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                fi
+              fi
+            done
+          }
+
+          # Process env_secret for masking
+          process_secret "$(cat <<'EOF'
+          ${{ secrets.env_secret }}
+          EOF
+          )"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -75,8 +75,8 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      rds_proxy:
-        description: "Start/stop the RDS Proxy"
+      pre_run_script:
+        description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
         default: false
         type: boolean
@@ -179,45 +179,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: |
-            if [ "${{ inputs.rds_proxy }}" = true ]; then
-              set -e
-
-              # Install netcat
-              apt-get update && apt-get install -y netcat-openbsd
-
-              # Install awscli v2
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip awscliv2.zip
-              ./aws/install
-
-              # Install kubectl
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-              chmod +x kubectl
-              mv kubectl /usr/local/bin/
-
-              # Start RDS Proxy
-              echo "Starting RDS proxy"
-              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
-
-              sleep 5
-
-              # Check if RDS proxy started
-              echo "Checking if RDS proxy started..."
-              for i in {1..6}; do
-                if nc -z localhost 5432; then
-                  echo "✅ RDS proxy is ready!"
-                  break
-                elif [ $i -eq 6 ]; then
-                  echo "❌ RDS proxy failed to start after 30 seconds"
-                  docker logs rds-proxy
-                  exit 1
-                else
-                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
-                  sleep 5
-                fi
-              done
-            fi
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -86,12 +86,12 @@ on:
         default: false
         type: boolean
       incidentio_alert_token:
-        description: "Incident.io alert token"
+        description: "Incident.io alert token Secrets Manager source (ENVVAR, /secret/path)"
         required: false
         type: string
         default: 'INCIDENT_ALERT_TOKEN, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_api_key'
       incidentio_alert_source:
-        description: "Incident.io alert source"
+        description: "Incident.io alert source Secrets Manager source (ENVVAR, /secret/path)"
         required: false
         type: string
         default: 'INCIDENT_ALERT_SOURCE, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_alert_source'
@@ -136,6 +136,14 @@ jobs:
         with:
           secret-ids: |
             ${{ inputs.secrets_manager_keys }}
+          name-transformation: none
+
+      # Skip reading incident secrets if none given or alert is disabled
+      - name: Read Incident.io secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
+        if: ${{ !inputs.disable_incidentio_alert && (inputs.incidentio_alert_token != '' && inputs.incidentio_alert_source != '') }}
+        with:
+          secret-ids: |
             ${{ inputs.incidentio_alert_token }}
             ${{ inputs.incidentio_alert_source }}
           name-transformation: none
@@ -186,7 +194,7 @@ jobs:
 
       - name: Create Incident.io Alert on Drift
         id: create-alert
-        if: inputs.disable_incidentio_alert == false && steps.opentofu-check.outputs.failure-reason == 'changes-to-apply'
+        if: ${{ !inputs.disable_incidentio_alert && steps.opentofu-check.outputs.failure-reason == 'changes-to-apply' }}
         run: |
           echo "OpenTofu check failed - drift detected in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \
@@ -203,7 +211,7 @@ jobs:
 
       - name: Create Incident.io Alert on Error
         id: create-error-alert
-        if: inputs.disable_incidentio_alert == false && steps.opentofu-check.outcome == 'failure' && steps.opentofu-check.outputs.failure-reason != 'changes-to-apply'
+        if: ${{ !inputs.disable_incidentio_alert && steps.opentofu-check.outcome == 'failure' && steps.opentofu-check.outputs.failure-reason != 'changes-to-apply' }}
         run: |
           echo "OpenTofu check failed - error detecting drift in ${{ inputs.environment }} for repository ${{ github.repository }}"
           curl \

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -75,15 +75,6 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      cloudflare_setup_warp_client:
-        description: "Setup Cloudflare WARP Client"
-        required: false
-        default: false
-        type: boolean
-      cloudflare_organization:
-        description: "Cloudflare organization"
-        required: false
-        type: string
       rds_proxy:
         description: "Start/stop the RDS Proxy"
         required: false

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -1,0 +1,303 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+name: OpenTofu Check
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Name of the environment to use"
+        required: true
+        type: string
+      opentofu_workspace:
+        description: "Name of the OpenTofu workspace to use, defaults to environment"
+        required: false
+        default: ""
+        type: string
+      opentofu_variables:
+        description: "Variables to pass to OpenTofu"
+        required: false
+        default: ""
+        type: string
+      opentofu_backend_config:
+        description: "Backend configuration for OpenTofu"
+        required: false
+        default: ""
+        type: string
+      opentofu_plan_label:
+        description: "Label for the OpenTofu plan output, defaults to environment"
+        required: false
+        default: ""
+        type: string
+      opentofu_var_file:
+        description: "List of var file paths, one per line"
+        required: false
+        default: ""
+        type: string
+      opentofu_path:
+        description: "Path to the OpenTofu directory"
+        required: false
+        default: "."
+        type: string
+      oidc_role_arn:
+        description: "ARN of the IAM role to assume with OIDC"
+        required: true
+        default: ""
+        type: string
+      oidc_audience:
+        description: "OIDC audience to authenticate against"
+        required: false
+        default: "sts.amazonaws.com"
+        type: string
+      oidc_region:
+        description: "Default region for AWS client"
+        required: false
+        default: us-east-2
+        type: string
+      trigger_check:
+        description: "Whether to trigger the OpenTofu check job"
+        required: false
+        default: true
+        type: boolean
+      env:
+        description: "Extra environment variables"
+        required: false
+        type: string
+      secrets_manager_keys:
+        description: "List of keys to fetch from AWS Secrets Manager"
+        required: false
+        type: string
+      artifact_name:
+        description: "The artifact name to download"
+        required: false
+        type: string
+      artifact_path:
+        description: "The artifact path to download"
+        required: false
+        type: string
+      cloudflare_setup_warp_client:
+        description: "Setup Cloudflare WARP Client"
+        required: false
+        default: false
+        type: boolean
+      cloudflare_organization:
+        description: "Cloudflare organization"
+        required: false
+        type: string
+      rds_proxy:
+        description: "Start/stop the RDS Proxy"
+        required: false
+        default: false
+        type: boolean
+      disable_incidentio_alert:
+        description: "Disable Incident.io alert creation on drift detection"
+        required: false
+        default: false
+        type: boolean
+      incidentio_alert_token:
+        description: "Incident.io alert token"
+        required: false
+        type: string
+        default: 'INCIDENT_ALERT_TOKEN, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_api_key'
+      incidentio_alert_source:
+        description: "Incident.io alert source"
+        required: false
+        type: string
+        default: 'INCIDENT_ALERT_SOURCE, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_alert_source'
+    secrets:
+      env_secret:
+        description: "Extra secret environment variables"
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  opentofu_check:
+    runs-on: ubuntu-latest
+    name: "OpenTofu Check - ${{ inputs.environment }}"
+    if: ${{ inputs.trigger_check }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Environment Variables
+        id: set-env
+        run: |
+          echo -e '${{ inputs.env }}' >> $GITHUB_ENV
+          for val in $(echo -e '${{ secrets.env_secret }}' | cut -d'=' -f2-); do echo ::add-mask::$val ; done
+          echo -e '${{ secrets.env_secret }}' >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: ${{ inputs.oidc_audience }}
+          role-to-assume: ${{ inputs.oidc_role_arn }}
+          aws-region: ${{ inputs.oidc_region }}
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        if: ${{ inputs.secrets_manager_keys != '' }}
+        with:
+          secret-ids: |
+            ${{ inputs.secrets_manager_keys }}
+            ${{ inputs.incidentio_alert_token }}
+            ${{ inputs.incidentio_alert_source }}
+          name-transformation: none
+
+      # For each env var the match TERRAFORM_HTTP_CREDENTIALS_*, add it to the TERRAFORM_HTTP_CREDENTIALS with a newline
+      - name: Set Terraform HTTP Credentials
+        run: |
+          # Initialize TERRAFORM_HTTP_CREDENTIALS if not set
+          : "${TERRAFORM_HTTP_CREDENTIALS:=""}"
+
+          # Find credential variables
+          credential_vars=$(compgen -A variable | grep '^TERRAFORM_HTTP_CREDENTIALS_' || true)
+
+          if [ -n "$credential_vars" ]; then
+            for var in $credential_vars; do
+              # Validate credential format
+              if [ -z "${!var}" ]; then
+                echo "::error::Empty credential found in $var"
+                exit 1
+              fi
+              TERRAFORM_HTTP_CREDENTIALS="${TERRAFORM_HTTP_CREDENTIALS}${!var}"$'\n'
+            done
+            # Export multi-line environment variable for subsequent steps
+            echo "TERRAFORM_HTTP_CREDENTIALS<<EOF" >> $GITHUB_ENV
+            echo "$TERRAFORM_HTTP_CREDENTIALS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
+          fi
+
+      - name: OpenTofu Check
+        id: opentofu-check
+        continue-on-error: true
+        uses: dflook/tofu-check@911a3cb9355a0f21f333b3fb4ec506df6a2e9a52 # v2.2.3
+        with:
+          label: ${{ inputs.opentofu_plan_label || inputs.environment }}
+          workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
+          backend_config: ${{ inputs.opentofu_backend_config }}
+          var_file: ${{ inputs.opentofu_var_file }}
+          path: ${{ inputs.opentofu_path }}
+          variables: |
+            ${{ inputs.opentofu_variables }}
+        env:
+          TERRAFORM_PRE_RUN: |
+            if [ "${{ inputs.rds_proxy }}" = true ]; then
+              set -e
+
+              # Install netcat
+              apt-get update && apt-get install -y netcat-openbsd
+
+              # Install awscli v2
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              ./aws/install
+
+              # Install kubectl
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              # Start RDS Proxy
+              echo "Starting RDS proxy"
+              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
+
+              sleep 5
+
+              # Check if RDS proxy started
+              echo "Checking if RDS proxy started..."
+              for i in {1..6}; do
+                if nc -z localhost 5432; then
+                  echo "✅ RDS proxy is ready!"
+                  break
+                elif [ $i -eq 6 ]; then
+                  echo "❌ RDS proxy failed to start after 30 seconds"
+                  docker logs rds-proxy
+                  exit 1
+                else
+                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
+                  sleep 5
+                fi
+              done
+            fi
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+
+      - name: Create Incident.io Alert on Drift
+        id: create-alert
+        if: inputs.disable_incidentio_alert == false && steps.opentofu-check.outputs.failure-reason == 'changes-to-apply'
+        run: |
+          echo "OpenTofu check failed - drift detected in ${{ inputs.environment }} for repository ${{ github.repository }}"
+          curl \
+            -X POST \
+            -H 'Authorization: Bearer ${{ env.INCIDENT_ALERT_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+              https://api.incident.io/v2/alert_events/http/${{ env.INCIDENT_ALERT_SOURCE }} \
+            -d '{
+              "title": "${{ github.repository }} Drift Detected",
+              "description": "OpenTofu drift detected in ${{ github.repository }} environment: ${{ inputs.environment }}. View workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "deduplication_key": "${{ github.repository }}-drift-${{ inputs.environment }}",
+              "status": "firing"
+            }'
+
+      - name: Create Incident.io Alert on Error
+        id: create-error-alert
+        if: inputs.disable_incidentio_alert == false && steps.opentofu-check.outcome == 'failure' && steps.opentofu-check.outputs.failure-reason != 'changes-to-apply'
+        run: |
+          echo "OpenTofu check failed - error detecting drift in ${{ inputs.environment }} for repository ${{ github.repository }}"
+          curl \
+            -X POST \
+            -H 'Authorization: Bearer ${{ env.INCIDENT_ALERT_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+              https://api.incident.io/v2/alert_events/http/${{ env.INCIDENT_ALERT_SOURCE }} \
+            -d '{
+              "title": "${{ github.repository }} Drift Detection Error",
+              "description": "Error detecting OpenTofu drift in ${{ github.repository }} environment: ${{ inputs.environment }}. View workflow run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "deduplication_key": "${{ github.repository }}-drift-${{ inputs.environment }}",
+              "status": "firing"
+            }'
+
+      - name: Check Workflow Status
+        if: always()
+        run: |
+          # Separate print statements if alert creation is disabled
+          if [[ "${{ inputs.disable_incidentio_alert }}" == "true" ]]; then
+            if [[ "${{ steps.opentofu-check.outputs.failure-reason }}" == "changes-to-apply" ]]; then
+              echo "⚠️ Drift detected but Incident.io alert creation is disabled"
+              exit 0
+            elif [[ "${{ steps.opentofu-check.outcome }}" == "success" ]]; then
+              echo "✅ No drift detected"
+              exit 0
+            else
+              echo "❌ Failure to run drift detection"
+              exit 1
+            fi
+          else
+            if [[ "${{ steps.opentofu-check.outputs.failure-reason }}" == "changes-to-apply" && "${{ steps.create-alert.outcome }}" == "success" ]]; then
+              echo "✅ Drift detected and successfully sent to Incident.io"
+              exit 0
+            elif [[ "${{ steps.opentofu-check.outputs.failure-reason }}" == "changes-to-apply" && "${{ steps.create-alert.outcome }}" != "success" ]]; then
+              echo "❌ Drift detected and alert creation failed"
+              exit 1
+            elif [[ "${{ steps.opentofu-check.outcome }}" == "success" ]]; then
+              echo "✅ No drift detected"
+              exit 0
+            elif [[ "${{ steps.opentofu-check.outputs.failure-reason }}" != "changes-to-apply" && "${{ steps.create-error-alert.outcome }}" == "success" ]]; then
+              echo "⚠️ Drift detection error and alert creation succeeded"
+              exit 1
+            elif [[ "${{ steps.opentofu-check.outputs.failure-reason }}" != "changes-to-apply" && "${{ steps.create-error-alert.outcome }}" != "success" ]]; then
+              echo "❌ Drift detection error and alert creation failed"
+              exit 1
+            else
+              echo "❌ Failure to run drift detection"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -185,6 +185,14 @@ jobs:
             echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
           fi
 
+      # Conditionally download the artifact if the artifact_name input is provided
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || '.' }}
+
       - name: OpenTofu Check
         id: opentofu-check
         continue-on-error: true

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -73,18 +73,18 @@ on:
       enable_incidentio_alert:
         description: "Enable Incident.io alert creation on drift detection"
         required: false
-        default: true
+        default: false
         type: boolean
       incidentio_alert_token:
         description: "Incident.io alert token Secrets Manager source (ENVVAR, /secret/path)"
         required: false
         type: string
-        default: 'INCIDENT_ALERT_TOKEN, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_api_key'
+        default: ''
       incidentio_alert_source:
         description: "Incident.io alert source Secrets Manager source (ENVVAR, /secret/path)"
         required: false
         type: string
-        default: 'INCIDENT_ALERT_SOURCE, /cloudops/managed-secrets/cloud/incidentio/lfx_terraform_alert_source'
+        default: ''
     secrets:
       env_secret:
         description: "Extra secret environment variables"

--- a/.github/workflows/lfx-opentofu-check.yml
+++ b/.github/workflows/lfx-opentofu-check.yml
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Environment Variables
         id: set-env
@@ -131,7 +131,7 @@ jobs:
 
       # This is used to fetch build time secrets from AWS Secrets Manager
       - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
         if: ${{ inputs.secrets_manager_keys != '' }}
         with:
           secret-ids: |

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -102,6 +102,7 @@ jobs:
         run: |
           # Add env_secret to environment using heredoc to preserve all characters
           cat <<'EOF' >> $GITHUB_ENV
+          ${{ inputs.env }}
           ${{ secrets.env_secret }}
           EOF
 
@@ -220,6 +221,7 @@ jobs:
         run: |
           # Add env_secret to environment using heredoc to preserve all characters
           cat <<'EOF' >> $GITHUB_ENV
+          ${{ inputs.env }}
           ${{ secrets.env_secret }}
           EOF
 

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -14,27 +14,22 @@ on:
       opentofu_workspace:
         description: 'Name of the OpenTofu workspace to use, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_variables:
         description: 'Variables to pass to OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_backend_config:
         description: 'Backend configuration for OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_plan_label:
         description: 'Label for the OpenTofu plan output, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_var_file:
         description: 'List of var file paths, one per line'
         required: false
-        default: ''
         type: string
       opentofu_add_github_comment:
         description: 'Add the plan to a GitHub PR'
@@ -49,7 +44,6 @@ on:
       oidc_role_arn:
         description: 'ARN of the IAM role to assume with OIDC'
         required: true
-        default: ''
         type: string
       oidc_audience:
         description: 'OIDC audience to authenticate against'
@@ -61,11 +55,6 @@ on:
         required: false
         default: us-east-2
         type: string
-      trigger_plan:
-        description: 'Whether to trigger the OpenTofu plan job'
-        required: false
-        default: true
-        type: boolean
       env:
         description: 'Extra environment variables'
         required: false
@@ -85,8 +74,7 @@ on:
       pre_run_script:
         description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
-        default: false
-        type: boolean
+        type: string
     secrets:
       env_secret:
         description: 'Extra secret environment variables'
@@ -103,7 +91,6 @@ jobs:
     outputs:
       tf_plan: ${{ steps.tofu-plan.outputs.plan_path }}
     name: "OpenTofu Plan/Apply Plan - ${{ inputs.environment }}"
-    if: ${{ inputs.trigger_plan }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -1,3 +1,7 @@
+---
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 name: OpenTofu Plan/Apply
 
 on:

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -78,15 +78,6 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      cloudflare_setup_warp_client:
-        description: "Setup Cloudflare WARP Client"
-        required: false
-        default: false
-        type: boolean
-      cloudflare_organization:
-        description: "Cloudflare organization"
-        required: false
-        type: string
       rds_proxy:
         description: "Start/stop the RDS Proxy"
         required: false
@@ -142,10 +133,6 @@ jobs:
           EOF
           )"
 
-          # Mask individual secrets directly
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -194,16 +181,6 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_path || '.' }}
-
-      # Cloudflare WARP client setup if needed
-      - name: "Cloudflare Warp Setup"
-        if: ${{ inputs.cloudflare_setup_warp_client }}
-        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
-        with:
-          organization: ${{ inputs.cloudflare_organization }}
-          # Get secrets from environment variables exported by secretsmanager
-          auth_client_id: ${{ env.cloudflare_auth_client_id }}
-          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
 
       - name: OpenTofu Plan
         uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3
@@ -312,10 +289,6 @@ jobs:
           EOF
           )"
 
-          # Mask individual secrets directly
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -371,16 +344,6 @@ jobs:
         with:
           name: tofu-plan-${{ inputs.environment }}
           path: ${{ inputs.opentofu_path }}
-
-      # Cloudflare WARP client setup if needed
-      - name: "Cloudflare Warp Setup"
-        if: ${{ inputs.cloudflare_setup_warp_client }}
-        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
-        with:
-          organization: ${{ inputs.cloudflare_organization }}
-          # Get secrets from environment variables exported by secretsmanager
-          auth_client_id: ${{ env.cloudflare_auth_client_id }}
-          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
 
       - name: OpenTofu Apply
         uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -78,8 +78,8 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      rds_proxy:
-        description: "Start/stop the RDS Proxy"
+      pre_run_script:
+        description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
         default: false
         type: boolean
@@ -195,45 +195,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: |
-            if [ "${{ inputs.rds_proxy }}" = true ]; then
-              set -euo pipefail
-
-              # Install netcat
-              apt-get update && apt-get install -y netcat-openbsd
-
-              # Install awscli v2
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip awscliv2.zip
-              ./aws/install
-
-              # Install kubectl
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-              chmod +x kubectl
-              mv kubectl /usr/local/bin/
-
-              # Start RDS Proxy
-              echo "Starting RDS proxy"
-              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
-
-              sleep 5
-
-              # Check if RDS proxy started
-              echo "Checking if RDS proxy started..."
-              for i in {1..6}; do
-                if nc -z localhost 5432; then
-                  echo "✅ RDS proxy is ready!"
-                  break
-                elif [ $i -eq 6 ]; then
-                  echo "❌ RDS proxy failed to start after 30 seconds"
-                  docker logs rds-proxy
-                  exit 1
-                else
-                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
-                  sleep 5
-                fi
-              done
-            fi
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
@@ -358,45 +320,7 @@ jobs:
           plan_path: tofu.tfplan
           auto_approve: true
         env:
-          TERRAFORM_PRE_RUN: |
-            if [ "${{ inputs.rds_proxy }}" = true ]; then
-              set -euo pipefail
-
-              # Install netcat
-              apt-get update && apt-get install -y netcat-openbsd
-
-              # Install awscli v2
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip awscliv2.zip
-              ./aws/install
-
-              # Install kubectl
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-              chmod +x kubectl
-              mv kubectl /usr/local/bin/
-
-              # Start RDS Proxy
-              echo "Starting RDS proxy"
-              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
-
-              sleep 5
-
-              # Check if RDS proxy started
-              echo "Checking if RDS proxy started..."
-              for i in {1..6}; do
-                if nc -z localhost 5432; then
-                  echo "✅ RDS proxy is ready!"
-                  break
-                elif [ $i -eq 6 ]; then
-                  echo "❌ RDS proxy failed to start after 30 seconds"
-                  docker logs rds-proxy
-                  exit 1
-                else
-                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
-                  sleep 5
-                fi
-              done
-            fi
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -186,7 +186,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_script }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
@@ -311,7 +311,7 @@ jobs:
           plan_path: tofu.tfplan
           auto_approve: true
         env:
-          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_script }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -1,0 +1,439 @@
+name: OpenTofu Plan/Apply
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Name of the environment to use'
+        required: true
+        type: string
+      opentofu_workspace:
+        description: 'Name of the OpenTofu workspace to use, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_variables:
+        description: 'Variables to pass to OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_backend_config:
+        description: 'Backend configuration for OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_plan_label:
+        description: 'Label for the OpenTofu plan output, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_var_file:
+        description: 'List of var file paths, one per line'
+        required: false
+        default: ''
+        type: string
+      opentofu_add_github_comment:
+        description: 'Add the plan to a GitHub PR'
+        required: false
+        default: 'true'
+        type: string
+      opentofu_path:
+        description: 'Path to the OpenTofu directory'
+        required: false
+        default: '.'
+        type: string
+      oidc_role_arn:
+        description: 'ARN of the IAM role to assume with OIDC'
+        required: true
+        default: ''
+        type: string
+      oidc_audience:
+        description: 'OIDC audience to authenticate against'
+        required: false
+        default: 'sts.amazonaws.com'
+        type: string
+      oidc_region:
+        description: 'Default region for AWS client'
+        required: false
+        default: us-east-2
+        type: string
+      trigger_plan:
+        description: 'Whether to trigger the OpenTofu plan job'
+        required: false
+        default: true
+        type: boolean
+      env:
+        description: 'Extra environment variables'
+        required: false
+        type: string
+      secrets_manager_keys:
+        description: 'List of keys to fetch from AWS Secrets Manager'
+        required: false
+        type: string
+      artifact_name:
+        description: "The artifact name to download"
+        required: false
+        type: string
+      artifact_path:
+        description: "The artifact path to download"
+        required: false
+        type: string
+      cloudflare_setup_warp_client:
+        description: "Setup Cloudflare WARP Client"
+        required: false
+        default: false
+        type: boolean
+      cloudflare_organization:
+        description: "Cloudflare organization"
+        required: false
+        type: string
+      rds_proxy:
+        description: "Start/stop the RDS Proxy"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      env_secret:
+        description: 'Extra secret environment variables'
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  opentofu_plan:
+    runs-on: ubuntu-latest
+    outputs:
+      tf_plan: ${{ steps.tofu-plan.outputs.plan_path }}
+    name: "OpenTofu Plan/Apply Plan - ${{ inputs.environment }}"
+    if: ${{ inputs.trigger_plan }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Environment Variables
+        id: set-env
+        shell: bash
+        run: |
+          # Add env_secret to environment using heredoc to preserve all characters
+          cat <<'EOF' >> $GITHUB_ENV
+          ${{ secrets.env_secret }}
+          EOF
+
+          # Function to safely process each line of a secret
+          process_secret() {
+            # Use printf to avoid echo interpretation issues
+            printf "%s\n" "$1" | while IFS= read -r line; do
+              if [[ "$line" == *"="* ]]; then
+                value="${line#*=}"
+                if [[ -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                fi
+              fi
+            done
+          }
+
+          # Process env_secret for masking
+          process_secret "$(cat <<'EOF'
+          ${{ secrets.env_secret }}
+          EOF
+          )"
+
+          # Mask individual secrets directly
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: ${{ inputs.oidc_audience }}
+          role-to-assume: ${{ inputs.oidc_role_arn }}
+          aws-region: ${{ inputs.oidc_region }}
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        if: ${{ inputs.secrets_manager_keys != '' }}
+        with:
+          secret-ids: ${{ inputs.secrets_manager_keys }}
+          name-transformation: none
+
+      # For each env var that matches TERRAFORM_HTTP_CREDENTIALS_* add it to the TERRAFORM_HTTP_CREDENTIALS with a newline
+      - name: Set Terraform HTTP Credentials
+        run: |
+          # Initialize TERRAFORM_HTTP_CREDENTIALS if not set
+          : "${TERRAFORM_HTTP_CREDENTIALS:=""}"
+
+          # Find credential variables
+          credential_vars=$(compgen -A variable | grep '^TERRAFORM_HTTP_CREDENTIALS_' || true)
+
+          if [ -n "$credential_vars" ]; then
+            for var in $credential_vars; do
+              # Validate credential format
+              if [ -z "${!var}" ]; then
+                echo "::error::Empty credential found in $var"
+                exit 1
+              fi
+              TERRAFORM_HTTP_CREDENTIALS="${TERRAFORM_HTTP_CREDENTIALS}${!var}"$'\n'
+            done
+            # Export multi-line environment variable for subsequent steps
+            echo "TERRAFORM_HTTP_CREDENTIALS<<EOF" >> $GITHUB_ENV
+            echo "$TERRAFORM_HTTP_CREDENTIALS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
+          fi
+
+      # Conditionally download the artifact if the artifact_name input is provided
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || '.' }}
+
+      # Cloudflare WARP client setup if needed
+      - name: "Cloudflare Warp Setup"
+        if: ${{ inputs.cloudflare_setup_warp_client }}
+        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
+        with:
+          organization: ${{ inputs.cloudflare_organization }}
+          # Get secrets from environment variables exported by secretsmanager
+          auth_client_id: ${{ env.cloudflare_auth_client_id }}
+          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
+
+      - name: OpenTofu Plan
+        uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3
+        id: tofu-plan
+        with:
+          label: ${{ inputs.opentofu_plan_label || inputs.environment }}
+          workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
+          backend_config: ${{ inputs.opentofu_backend_config }}
+          var_file: ${{ inputs.opentofu_var_file }}
+          add_github_comment: ${{ inputs.opentofu_add_github_comment }}
+          path: ${{ inputs.opentofu_path }}
+          variables: |
+            ${{ inputs.opentofu_variables }}
+        env:
+          TERRAFORM_PRE_RUN: |
+            if [ "${{ inputs.rds_proxy }}" = true ]; then
+              set -euo pipefail
+
+              # Install netcat
+              apt-get update && apt-get install -y netcat-openbsd
+
+              # Install awscli v2
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              ./aws/install
+
+              # Install kubectl
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              # Start RDS Proxy
+              echo "Starting RDS proxy"
+              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
+
+              sleep 5
+
+              # Check if RDS proxy started
+              echo "Checking if RDS proxy started..."
+              for i in {1..6}; do
+                if nc -z localhost 5432; then
+                  echo "✅ RDS proxy is ready!"
+                  break
+                elif [ $i -eq 6 ]; then
+                  echo "❌ RDS proxy failed to start after 30 seconds"
+                  docker logs rds-proxy
+                  exit 1
+                else
+                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
+                  sleep 5
+                fi
+              done
+            fi
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
+
+      - name: Save plan output
+        id: plan-output-path
+        run: |
+          cp ${{ steps.tofu-plan.outputs.plan_path }} tofu.tfplan
+          echo "plan_path=tofu.tfplan" >> $GITHUB_OUTPUT
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: tofu-plan-${{ inputs.environment }}
+          path: ${{ steps.plan-output-path.outputs.plan_path }}
+          retention-days: 1
+
+  opentofu_apply:
+    runs-on: ubuntu-latest
+    needs: opentofu_plan
+    name: "OpenTofu Plan/Apply Apply - ${{ inputs.environment }}"
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Environment Variables
+        id: set-env
+        shell: bash
+        run: |
+          # Add env_secret to environment using heredoc to preserve all characters
+          cat <<'EOF' >> $GITHUB_ENV
+          ${{ secrets.env_secret }}
+          EOF
+
+          # Function to safely process each line of a secret
+          process_secret() {
+            # Use printf to avoid echo interpretation issues
+            printf "%s\n" "$1" | while IFS= read -r line; do
+              if [[ "$line" == *"="* ]]; then
+                value="${line#*=}"
+                if [[ -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                fi
+              fi
+            done
+          }
+
+          # Process env_secret for masking
+          process_secret "$(cat <<'EOF'
+          ${{ secrets.env_secret }}
+          EOF
+          )"
+
+          # Mask individual secrets directly
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: ${{ inputs.oidc_audience }}
+          role-to-assume: ${{ inputs.oidc_role_arn }}
+          aws-region: ${{ inputs.oidc_region }}
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        if: ${{ inputs.secrets_manager_keys != '' }}
+        with:
+          secret-ids: ${{ inputs.secrets_manager_keys }}
+          name-transformation: none
+
+      # For each env var that matches TERRAFORM_HTTP_CREDENTIALS_* add it to the TERRAFORM_HTTP_CREDENTIALS with a newline
+      - name: Set Terraform HTTP Credentials
+        run: |
+          # Initialize TERRAFORM_HTTP_CREDENTIALS if not set
+          : "${TERRAFORM_HTTP_CREDENTIALS:=""}"
+
+          # Find credential variables
+          credential_vars=$(compgen -A variable | grep '^TERRAFORM_HTTP_CREDENTIALS_' || true)
+
+          if [ -n "$credential_vars" ]; then
+            for var in $credential_vars; do
+              # Validate credential format
+              if [ -z "${!var}" ]; then
+                echo "::error::Empty credential found in $var"
+                exit 1
+              fi
+              TERRAFORM_HTTP_CREDENTIALS="${TERRAFORM_HTTP_CREDENTIALS}${!var}"$'\n'
+            done
+            # Export multi-line environment variable for subsequent steps
+            echo "TERRAFORM_HTTP_CREDENTIALS<<EOF" >> $GITHUB_ENV
+            echo "$TERRAFORM_HTTP_CREDENTIALS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
+          fi
+
+      # Conditionally download the artifact if the artifact_name input is provided
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || '.' }}
+
+      # Download the plan artifact from the plan job
+      - name: Download plan artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tofu-plan-${{ inputs.environment }}
+          path: ${{ inputs.opentofu_path }}
+
+      # Cloudflare WARP client setup if needed
+      - name: "Cloudflare Warp Setup"
+        if: ${{ inputs.cloudflare_setup_warp_client }}
+        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
+        with:
+          organization: ${{ inputs.cloudflare_organization }}
+          # Get secrets from environment variables exported by secretsmanager
+          auth_client_id: ${{ env.cloudflare_auth_client_id }}
+          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
+
+      - name: OpenTofu Apply
+        uses: dflook/tofu-apply@c254eb5b2e48978c05587373100d26b604c2182d # v2.2.3
+        with:
+          label: ${{ inputs.opentofu_plan_label || inputs.environment }}
+          workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
+          backend_config: ${{ inputs.opentofu_backend_config }}
+          var_file: ${{ inputs.opentofu_var_file }}
+          path: ${{ inputs.opentofu_path }}
+          variables: |
+            ${{ inputs.opentofu_variables }}
+          plan_path: tofu.tfplan
+          auto_approve: true
+        env:
+          TERRAFORM_PRE_RUN: |
+            if [ "${{ inputs.rds_proxy }}" = true ]; then
+              set -euo pipefail
+
+              # Install netcat
+              apt-get update && apt-get install -y netcat-openbsd
+
+              # Install awscli v2
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              ./aws/install
+
+              # Install kubectl
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              # Start RDS Proxy
+              echo "Starting RDS proxy"
+              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
+
+              sleep 5
+
+              # Check if RDS proxy started
+              echo "Checking if RDS proxy started..."
+              for i in {1..6}; do
+                if nc -z localhost 5432; then
+                  echo "✅ RDS proxy is ready!"
+                  break
+                elif [ $i -eq 6 ]; then
+                  echo "❌ RDS proxy failed to start after 30 seconds"
+                  docker logs rds-proxy
+                  exit 1
+                else
+                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
+                  sleep 5
+                fi
+              done
+            fi
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan-apply.yml
+++ b/.github/workflows/lfx-opentofu-plan-apply.yml
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Environment Variables
         id: set-env
@@ -142,7 +142,7 @@ jobs:
 
       # This is used to fetch build time secrets from AWS Secrets Manager
       - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
         if: ${{ inputs.secrets_manager_keys != '' }}
         with:
           secret-ids: ${{ inputs.secrets_manager_keys }}
@@ -245,7 +245,7 @@ jobs:
           echo "plan_path=tofu.tfplan" >> $GITHUB_OUTPUT
 
       - name: Upload plan artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tofu-plan-${{ inputs.environment }}
           path: ${{ steps.plan-output-path.outputs.plan_path }}
@@ -259,7 +259,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Environment Variables
         id: set-env
@@ -298,7 +298,7 @@ jobs:
 
       # This is used to fetch build time secrets from AWS Secrets Manager
       - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
         if: ${{ inputs.secrets_manager_keys != '' }}
         with:
           secret-ids: ${{ inputs.secrets_manager_keys }}

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -183,7 +183,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_script }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -1,4 +1,9 @@
+---
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 name: OpenTofu Plan
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -77,15 +77,6 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      cloudflare_setup_warp_client:
-        description: "Setup Cloudflare WARP Client"
-        required: false
-        default: false
-        type: boolean
-      cloudflare_organization:
-        description: "Cloudflare organization"
-        required: false
-        type: string
       rds_proxy:
         description: "Start/stop the RDS Proxy"
         required: false
@@ -139,10 +130,6 @@ jobs:
           EOF
           )"
 
-          # Mask individual secrets directly
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
-          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -191,16 +178,6 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifact_path || '.' }}
-
-      # Cloudflare WARP client setup if needed
-      - name: "Cloudflare Warp Setup"
-        if: ${{ inputs.cloudflare_setup_warp_client }}
-        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
-        with:
-          organization: ${{ inputs.cloudflare_organization }}
-          # Get secrets from environment variables exported by secretsmanager
-          auth_client_id: ${{ env.cloudflare_auth_client_id }}
-          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
 
       - name: OpenTofu Plan
         uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           # Add env_secret to environment using heredoc to preserve all characters
           cat <<'EOF' >> $GITHUB_ENV
+          ${{ inputs.env }}
           ${{ secrets.env_secret }}
           EOF
 

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -77,8 +77,8 @@ on:
         description: "The artifact path to download"
         required: false
         type: string
-      rds_proxy:
-        description: "Start/stop the RDS Proxy"
+      pre_run_script:
+        description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
         default: false
         type: boolean
@@ -191,45 +191,7 @@ jobs:
           variables: |
             ${{ inputs.opentofu_variables }}
         env:
-          TERRAFORM_PRE_RUN: |
-            if [ "${{ inputs.rds_proxy }}" = true ]; then
-              set -euo pipefail
-
-              # Install netcat
-              apt-get update && apt-get install -y netcat-openbsd
-
-              # Install awscli v2
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-              unzip awscliv2.zip
-              ./aws/install
-
-              # Install kubectl
-              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-              chmod +x kubectl
-              mv kubectl /usr/local/bin/
-
-              # Start RDS Proxy
-              echo "Starting RDS proxy"
-              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
-
-              sleep 5
-
-              # Check if RDS proxy started
-              echo "Checking if RDS proxy started..."
-              for i in {1..6}; do
-                if nc -z localhost 5432; then
-                  echo "✅ RDS proxy is ready!"
-                  break
-                elif [ $i -eq 6 ]; then
-                  echo "❌ RDS proxy failed to start after 30 seconds"
-                  docker logs rds-proxy
-                  exit 1
-                else
-                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
-                  sleep 5
-                fi
-              done
-            fi
+          TERRAFORM_PRE_RUN: ${{ inputs.pre_run_commands }}
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set Environment Variables
         id: set-env
@@ -139,7 +139,7 @@ jobs:
 
       # This is used to fetch build time secrets from AWS Secrets Manager
       - name: Read secrets from AWS Secrets Manager into environment variables
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
         if: ${{ inputs.secrets_manager_keys != '' }}
         with:
           secret-ids: ${{ inputs.secrets_manager_keys }}

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -1,0 +1,258 @@
+name: OpenTofu Plan
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Name of the environment to use'
+        required: true
+        type: string
+      opentofu_workspace:
+        description: 'Name of the OpenTofu workspace to use, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_variables:
+        description: 'Variables to pass to OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_backend_config:
+        description: 'Backend configuration for OpenTofu'
+        required: false
+        default: ''
+        type: string
+      opentofu_plan_label:
+        description: 'Label for the OpenTofu plan output, defaults to environment'
+        required: false
+        default: ''
+        type: string
+      opentofu_var_file:
+        description: 'List of var file paths, one per line'
+        required: false
+        default: ''
+        type: string
+      opentofu_add_github_comment:
+        description: 'Add the plan to a GitHub PR'
+        required: false
+        default: 'true'
+        type: string
+      opentofu_path:
+        description: 'Path to the OpenTofu directory'
+        required: false
+        default: '.'
+        type: string
+      oidc_role_arn:
+        description: 'ARN of the IAM role to assume with OIDC'
+        required: true
+        default: ''
+        type: string
+      oidc_audience:
+        description: 'OIDC audience to authenticate against'
+        required: false
+        default: 'sts.amazonaws.com'
+        type: string
+      oidc_region:
+        description: 'Default region for AWS client'
+        required: false
+        default: us-east-2
+        type: string
+      trigger_plan:
+        description: 'Whether to trigger the OpenTofu plan job'
+        required: false
+        default: true
+        type: boolean
+      env:
+        description: 'Extra environment variables'
+        required: false
+        type: string
+      secrets_manager_keys:
+        description: 'List of keys to fetch from AWS Secrets Manager'
+        required: false
+        type: string
+      artifact_name:
+        description: "The artifact name to download"
+        required: false
+        type: string
+      artifact_path:
+        description: "The artifact path to download"
+        required: false
+        type: string
+      cloudflare_setup_warp_client:
+        description: "Setup Cloudflare WARP Client"
+        required: false
+        default: false
+        type: boolean
+      cloudflare_organization:
+        description: "Cloudflare organization"
+        required: false
+        type: string
+      rds_proxy:
+        description: "Start/stop the RDS Proxy"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      env_secret:
+        description: 'Extra secret environment variables'
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  opentofu_plan:
+    runs-on: ubuntu-latest
+    name: "OpenTofu Plan - ${{ inputs.environment }}"
+    if: ${{ inputs.trigger_plan }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set Environment Variables
+        id: set-env
+        shell: bash
+        run: |
+          # Add env_secret to environment using heredoc to preserve all characters
+          cat <<'EOF' >> $GITHUB_ENV
+          ${{ secrets.env_secret }}
+          EOF
+
+          # Function to safely process each line of a secret
+          process_secret() {
+            # Use printf to avoid echo interpretation issues
+            printf "%s\n" "$1" | while IFS= read -r line; do
+              if [[ "$line" == *"="* ]]; then
+                value="${line#*=}"
+                if [[ -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                fi
+              fi
+            done
+          }
+
+          # Process env_secret for masking
+          process_secret "$(cat <<'EOF'
+          ${{ secrets.env_secret }}
+          EOF
+          )"
+
+          # Mask individual secrets directly
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_id }}"
+          echo "::add-mask::${{ secrets.cloudflare_auth_client_secret }}"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          audience: ${{ inputs.oidc_audience }}
+          role-to-assume: ${{ inputs.oidc_role_arn }}
+          aws-region: ${{ inputs.oidc_region }}
+
+      # This is used to fetch build time secrets from AWS Secrets Manager
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        if: ${{ inputs.secrets_manager_keys != '' }}
+        with:
+          secret-ids: ${{ inputs.secrets_manager_keys }}
+          name-transformation: none
+
+      # For each env var that matches TERRAFORM_HTTP_CREDENTIALS_* add it to the TERRAFORM_HTTP_CREDENTIALS with a newline
+      - name: Set Terraform HTTP Credentials
+        run: |
+          # Initialize TERRAFORM_HTTP_CREDENTIALS if not set
+          : "${TERRAFORM_HTTP_CREDENTIALS:=""}"
+
+          # Find credential variables
+          credential_vars=$(compgen -A variable | grep '^TERRAFORM_HTTP_CREDENTIALS_' || true)
+
+          if [ -n "$credential_vars" ]; then
+            for var in $credential_vars; do
+              # Validate credential format
+              if [ -z "${!var}" ]; then
+                echo "::error::Empty credential found in $var"
+                exit 1
+              fi
+              TERRAFORM_HTTP_CREDENTIALS="${TERRAFORM_HTTP_CREDENTIALS}${!var}"$'\n'
+            done
+            # Export multi-line environment variable for subsequent steps
+            echo "TERRAFORM_HTTP_CREDENTIALS<<EOF" >> $GITHUB_ENV
+            echo "$TERRAFORM_HTTP_CREDENTIALS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "::warning::No TERRAFORM_HTTP_CREDENTIALS_* variables found"
+          fi
+
+      # Conditionally download the artifact if the artifact_name input is provided
+      - name: Download artifact
+        if: ${{ inputs.artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_path || '.' }}
+
+      # Cloudflare WARP client setup if needed
+      - name: "Cloudflare Warp Setup"
+        if: ${{ inputs.cloudflare_setup_warp_client }}
+        uses: Boostport/setup-cloudflare-warp@427fc9c04f371e4e0338701954d495c669ae7885 # v1.17.1
+        with:
+          organization: ${{ inputs.cloudflare_organization }}
+          # Get secrets from environment variables exported by secretsmanager
+          auth_client_id: ${{ env.cloudflare_auth_client_id }}
+          auth_client_secret: ${{ env.cloudflare_auth_client_secret }}
+
+      - name: OpenTofu Plan
+        uses: dflook/tofu-plan@3f5dc358343fb58cd60f83b019e810315aa8258f # v2.2.3
+        with:
+          label: ${{ inputs.opentofu_plan_label || inputs.environment }}
+          workspace: ${{ inputs.opentofu_workspace || inputs.environment }}
+          backend_config: ${{ inputs.opentofu_backend_config }}
+          var_file: ${{ inputs.opentofu_var_file }}
+          add_github_comment: ${{ inputs.opentofu_add_github_comment }}
+          path: ${{ inputs.opentofu_path }}
+          variables: |
+            ${{ inputs.opentofu_variables }}
+        env:
+          TERRAFORM_PRE_RUN: |
+            if [ "${{ inputs.rds_proxy }}" = true ]; then
+              set -euo pipefail
+
+              # Install netcat
+              apt-get update && apt-get install -y netcat-openbsd
+
+              # Install awscli v2
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip awscliv2.zip
+              ./aws/install
+
+              # Install kubectl
+              curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x kubectl
+              mv kubectl /usr/local/bin/
+
+              # Start RDS Proxy
+              echo "Starting RDS proxy"
+              ./scripts/rds-proxy.sh start ${{ inputs.environment }} terraform-deploy-oidc
+
+              sleep 5
+
+              # Check if RDS proxy started
+              echo "Checking if RDS proxy started..."
+              for i in {1..6}; do
+                if nc -z localhost 5432; then
+                  echo "✅ RDS proxy is ready!"
+                  break
+                elif [ $i -eq 6 ]; then
+                  echo "❌ RDS proxy failed to start after 30 seconds"
+                  docker logs rds-proxy
+                  exit 1
+                else
+                  echo "Attempt $i/6: Not ready yet, waiting 5 more seconds..."
+                  sleep 5
+                fi
+              done
+            fi
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/lfx-opentofu-plan.yml
+++ b/.github/workflows/lfx-opentofu-plan.yml
@@ -14,27 +14,22 @@ on:
       opentofu_workspace:
         description: 'Name of the OpenTofu workspace to use, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_variables:
         description: 'Variables to pass to OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_backend_config:
         description: 'Backend configuration for OpenTofu'
         required: false
-        default: ''
         type: string
       opentofu_plan_label:
         description: 'Label for the OpenTofu plan output, defaults to environment'
         required: false
-        default: ''
         type: string
       opentofu_var_file:
         description: 'List of var file paths, one per line'
         required: false
-        default: ''
         type: string
       opentofu_add_github_comment:
         description: 'Add the plan to a GitHub PR'
@@ -49,7 +44,6 @@ on:
       oidc_role_arn:
         description: 'ARN of the IAM role to assume with OIDC'
         required: true
-        default: ''
         type: string
       oidc_audience:
         description: 'OIDC audience to authenticate against'
@@ -61,11 +55,6 @@ on:
         required: false
         default: us-east-2
         type: string
-      trigger_plan:
-        description: 'Whether to trigger the OpenTofu plan job'
-        required: false
-        default: true
-        type: boolean
       env:
         description: 'Extra environment variables'
         required: false
@@ -85,8 +74,7 @@ on:
       pre_run_script:
         description: "Shell commands passed through as TERRAFORM_PRE_RUN to dflook action"
         required: false
-        default: false
-        type: boolean
+        type: string
     secrets:
       env_secret:
         description: 'Extra secret environment variables'
@@ -101,7 +89,6 @@ jobs:
   opentofu_plan:
     runs-on: ubuntu-latest
     name: "OpenTofu Plan - ${{ inputs.environment }}"
-    if: ${{ inputs.trigger_plan }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -16,12 +16,10 @@ on:
         description: "A comma-separated list of additional file patterns to include"
         required: false
         type: string
-        default: ""
       exclude_pattern:
         description: "A comma-separated list of additional patterns to exclude"
         required: false
         type: string
-        default: ""
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The public repository for shared workflows for projects under the `linuxfoundati
   | Input                         | Applies to           | Type    | Default                 | Description                                               |
   | ----------------------------- | -------------------- | ------- | ----------------------- | --------------------------------------------------------- |
   | `opentofu_add_github_comment` | `plan`, `plan-apply` | string  | `true`                  | Post the plan output as a comment on the PR               |
-  | `disable_incidentio_alert`    | `check`              | boolean | `false`                 | Disable Incident.io alert creation on drift detection     |
+  | `enable_incidentio_alert`     | `check`              | boolean | `true`                  | Enable Incident.io alert creation on drift detection      |
   | `incidentio_alert_token`      | `check`              | string  | _(managed secret path)_ | Incident.io alert token source (as `ENVVAR, /path/in/sm`) |
   | `incidentio_alert_source`     | `check`              | string  | _(managed secret path)_ | Incident.io alert source (as `ENVVAR, /path/in/sm`)       |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The public repository for shared workflows for projects under the `linuxfoundati
   Reusable workflows wrapping <https://github.com/dflook/terraform-github-actions> OpenTofu actions with extra setup
   glue for AWS login and secrets handling.
 
-  The standalone `plan` and `apply` workflows are indended for a plan-on-PR/merge-on-apply workflow, `check` is for reoccurring drift detection jobs, and `plan-apply` is for manual triggers outside of the PR process (e.g. for retrying or resolving drift).
+  The standalone `plan` and `apply` workflows are intended for a plan-on-PR/merge-on-apply workflow, `check` is for reoccurring drift detection jobs, and `plan-apply` is for manual triggers outside of the PR process (e.g. for retrying or resolving drift).
 
   Most inputs are shared across all four workflows:
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The public repository for shared workflows for projects under the `linuxfoundati
 
   A few inputs only apply to specific workflows:
 
-  | Input                         | Applies to           | Type    | Default                 | Description                                               |
-  | ----------------------------- | -------------------- | ------- | ----------------------- | --------------------------------------------------------- |
-  | `opentofu_add_github_comment` | `plan`, `plan-apply` | string  | `true`                  | Post the plan output as a comment on the PR               |
-  | `enable_incidentio_alert`     | `check`              | boolean | `true`                  | Enable Incident.io alert creation on drift detection      |
-  | `incidentio_alert_token`      | `check`              | string  | _(managed secret path)_ | Incident.io alert token source (as `ENVVAR, /path/in/sm`) |
-  | `incidentio_alert_source`     | `check`              | string  | _(managed secret path)_ | Incident.io alert source (as `ENVVAR, /path/in/sm`)       |
+  | Input                         | Applies to           | Type    | Default | Description                                               |
+  | ----------------------------- | -------------------- | ------- | ------- | --------------------------------------------------------- |
+  | `opentofu_add_github_comment` | `plan`, `plan-apply` | string  | `true`  | Post the plan output as a comment on the PR               |
+  | `enable_incidentio_alert`     | `check`              | boolean | `false` | Enable Incident.io alert creation on drift detection      |
+  | `incidentio_alert_token`      | `check`              | string  |         | Incident.io alert token source (as `ENVVAR, /path/in/sm`) |
+  | `incidentio_alert_source`     | `check`              | string  |         | Incident.io alert source (as `ENVVAR, /path/in/sm`)       |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,43 @@ The public repository for shared workflows for projects under the `linuxfoundati
 
   Reusable workflow for checking license headers in source code files.
 
+- **`lfx-opentofu-{plan,apply,check,plan-apply}`**
+
+  Reusable workflows wrapping <https://github.com/dflook/terraform-github-actions> OpenTofu actions with extra setup
+  glue for AWS login and secrets handling.
+
+  The standalone `plan` and `apply` workflows are indended for a plan-on-PR/merge-on-apply workflow, `check` is for reoccurring drift detection jobs, and `plan-apply` is for manual triggers outside of the PR process (e.g. for retrying or resolving drift).
+
+  Most inputs are shared across all four workflows:
+
+  | Input                     | Type   | Required | Default             | Description                                          |
+  | ------------------------- | ------ | -------- | ------------------- | ---------------------------------------------------- |
+  | `environment`             | string | yes      |                     | Name of the GHA environment to use                   |
+  | `opentofu_workspace`      | string |          | (environment input) | Name of the OpenTofu workspace to use                |
+  | `opentofu_variables`      | string |          |                     | Variables to pass to OpenTofu                        |
+  | `opentofu_backend_config` | string |          |                     | Backend configuration for OpenTofu                   |
+  | `opentofu_plan_label`     | string |          | (environment input) | Label for the OpenTofu plan output in PR comment     |
+  | `opentofu_var_file`       | string |          |                     | List of var file paths, one per line                 |
+  | `opentofu_path`           | string |          | `.`                 | Path to the OpenTofu directory                       |
+  | `oidc_role_arn`           | string | yes      |                     | ARN of the IAM role to assume with OIDC              |
+  | `oidc_audience`           | string |          | `sts.amazonaws.com` | OIDC audience to authenticate against                |
+  | `oidc_region`             | string |          | `us-east-2`         | Default region for the AWS client                    |
+  | `env`                     | string |          |                     | Additional environment variables                     |
+  | `secrets_manager_keys`    | string |          |                     | List of keys to fetch from AWS Secrets Manager       |
+  | `artifact_name`           | string |          |                     | Name of an artifact to download before running       |
+  | `artifact_path`           | string |          |                     | Path to download the artifact to                     |
+  | `pre_run_script`          | string |          |                     | Shell commands passed through as `TERRAFORM_PRE_RUN` |
+  | `secrets.env_secret`      | secret |          |                     | Additional secret environment variables              |
+
+  A few inputs only apply to specific workflows:
+
+  | Input                         | Applies to           | Type    | Default                 | Description                                               |
+  | ----------------------------- | -------------------- | ------- | ----------------------- | --------------------------------------------------------- |
+  | `opentofu_add_github_comment` | `plan`, `plan-apply` | string  | `true`                  | Post the plan output as a comment on the PR               |
+  | `disable_incidentio_alert`    | `check`              | boolean | `false`                 | Disable Incident.io alert creation on drift detection     |
+  | `incidentio_alert_token`      | `check`              | string  | _(managed secret path)_ | Incident.io alert token source (as `ENVVAR, /path/in/sm`) |
+  | `incidentio_alert_source`     | `check`              | string  | _(managed secret path)_ | Incident.io alert source (as `ENVVAR, /path/in/sm`)       |
+
 ## License
 
 Copyright The Linux Foundation and each contributor to LFX.


### PR DESCRIPTION
This copies over our internal Tofu PR wrapper workflows with some cleanup and changes to make them suitable for other LF projects we assist to consume. 

Breaking changes vs. our current ones:
- removed the hardcoded RDS proxy pre-run script in favor or arbitrary string input -- this is only used by a single repo and can be set there instead of the reusable workflow
- renamed the `disable_incidentio_alert` to `enable_incidentio_alert` to avoid a double-negative logic input

Other cleanup changes:
- removed Cloudflare WARP setup that we are no longer using
- made the incident.io check alert fully conditional so the check job can be used without failing hard on missing tokens if the SM keys do not exist
- cleaned up implicit empty string defaults
- bumped action pins